### PR TITLE
README.mdへのDB設計の記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,50 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## users テーブル
+|column||type||option|
+|------||----||------|
+|name||string||null: false|
+|email||text||null: false, unique: true|
+|password||string||null: false|
+
+## Association
+- has_many :messages
+- has_many :groups
+- has_many :users_groups
+- has_many :groups, through: :users_groups
+
+
+## groups テーブル
+|column||type||option|
+|------||----||------|
+|name||string||null: false, unique: true|
+
+## Association
+- has_many :users_groups
+- has_many :users, through: :users_groups
+
+
+## messages テーブル
+|column||type||option|
+|------||----||------|
+|message||text||null: false|
+|image||text|||
+|created_at||timestamp|
+|user_id||integer||null :false, foreign_ker: true|
+
+## Association
+- belongs_to :user
+
+
+## users_groups テーブル
+
+|column||type||option|
+|------||----||------|
+|user_id||integer||null: false, foreign_key: true|
+|group_id||integer||null: false, foreign_key: true|
+
+## Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Things you may want to cover:
 
 ## Association
 - has_many :messages
-- has_many :groups
 - has_many :users_groups
 - has_many :groups, through: :users_groups
 
@@ -45,18 +44,21 @@ Things you may want to cover:
 ## Association
 - has_many :users_groups
 - has_many :users, through: :users_groups
+- has_many :messages
 
 
 ## messages テーブル
 |column|type|option|
 |:------|:----|:------|
-|message|text|null: false|
+|message|text||
 |image|text||
 |created_at|timestamp|
-|user_id|integer|null :false, foreign_ker: true|
+|user_id|integer|null: false, foreign_ker: true|
+|group_id|integer|null: false, foreign_key: true|
 
 ## Association
 - belongs_to :user
+- belongs_to :group
 
 
 ## users_groups テーブル

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Things you may want to cover:
 * ...
 
 ## users テーブル
-|column||type||option|
-|------||----||------|
-|name||string||null: false|
-|email||text||null: false, unique: true|
-|password||string||null: false|
+|column|type|option|
+|:------|:----|:------|
+|name|string|null: false|
+|email|text|null: false, unique: true|
+|password|string|null: false|
 
 ## Association
 - has_many :messages
@@ -38,9 +38,9 @@ Things you may want to cover:
 
 
 ## groups テーブル
-|column||type||option|
-|------||----||------|
-|name||string||null: false, unique: true|
+|column|type|option|
+|:------|:----|:------|
+|name|string|null: false, unique: true|
 
 ## Association
 - has_many :users_groups
@@ -48,12 +48,12 @@ Things you may want to cover:
 
 
 ## messages テーブル
-|column||type||option|
-|------||----||------|
-|message||text||null: false|
-|image||text|||
-|created_at||timestamp|
-|user_id||integer||null :false, foreign_ker: true|
+|column|type|option|
+|:------|:----|:------|
+|message|text|null: false|
+|image|text||
+|created_at|timestamp|
+|user_id|integer|null :false, foreign_ker: true|
 
 ## Association
 - belongs_to :user
@@ -61,11 +61,12 @@ Things you may want to cover:
 
 ## users_groups テーブル
 
-|column||type||option|
-|------||----||------|
-|user_id||integer||null: false, foreign_key: true|
-|group_id||integer||null: false, foreign_key: true|
+|column|type|option|
+|:------|:----|:------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
 ## Association
 - belongs_to :group
 - belongs_to :user
+

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Things you may want to cover:
 |message|text||
 |image|text||
 |created_at|timestamp|
-|user_id|integer|null: false, foreign_ker: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_ker: true|
+|group|references|null: false, foreign_key: true|
 
 ## Association
 - belongs_to :user
@@ -65,8 +65,8 @@ Things you may want to cover:
 
 |column|type|option|
 |:------|:----|:------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ## Association
 - belongs_to :group


### PR DESCRIPTION
#what
chat-spaceのDB設計をREADMEへ記載する。chat-spaceで使用する各テーブルのカラム構成とアソシエーションを記載した。


#why
DB設計はアプリケーション開発において扱うデータの管理方法を決める重要な作業であるため。